### PR TITLE
Make config mountable

### DIFF
--- a/lbrycrd/Dockerfile
+++ b/lbrycrd/Dockerfile
@@ -25,7 +25,7 @@ COPY stuff/start.sh /usr/local/bin/start
 COPY stuff/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 COPY stuff/healthcheck.sh /usr/local/bin/healthcheck
 
-# USER lbrycrd
+USER lbrycrd
 # RUN mkdir /data
 VOLUME ["/data"]
 WORKDIR /data

--- a/lbrycrd/stuff/start.sh
+++ b/lbrycrd/stuff/start.sh
@@ -6,35 +6,39 @@
 # ## not specified it will only create an index for transactions that are related to the wallet or have unspent outputs.
 # ## This is specific to chainquery.
 
+# The config file does not exist in the container image. It must be mounted, or
+# if not, a default config is generated using environment variables.
+CONFIG_PATH=/etc/lbry/lbrycrd.conf
+if [ -f "$CONFIG_PATH" ]
+then
+    echo "Using the config file mounted into the container"
+else
+    echo "Creating fresh config file from environment variables"
+    ## Set config params
+    mkdir -p `dirname $CONFIG_PATH`
+    echo "rpcuser=$RPC_USER" > $CONFIG_PATH
+    echo "rpcpassword=$RPC_PASSWORD" >> $CONFIG_PATH
+    echo "rpcallowip=$RPC_ALLOW_IP" >> $CONFIG_PATH
+    echo "rpcport=9245" >> $CONFIG_PATH
+    echo "rpcbind=0.0.0.0" >> $CONFIG_PATH
+    #echo "bind=0.0.0.0" >> $CONFIG_PATH
+fi
+
 ## Ensure perms are correct prior to running main binary
-mkdir -p /data/.lbrycrd
 chown -R lbrycrd:lbrycrd /data
 chmod -R 755 /data/
 
-## TODO: Consider a config directory for future magic.
-# chown -R 1000:1000 /etc/lbrycrd
-# chmod -R 755 /etc/lbrycrd
 rm -f /var/run/lbrycrd.pid
-
-
-## Set config params
-## TODO: Make this more automagic in the future.
-echo "rpcuser=$RPC_USER" > /data/.lbrycrd/lbrycrd.conf
-echo "rpcpassword=$RPC_PASSWORD" >> /data/.lbrycrd/lbrycrd.conf
-echo "rpcallowip=$RPC_ALLOW_IP" >> /data/.lbrycrd/lbrycrd.conf
-echo "rpcport=9245" >> /data/.lbrycrd/lbrycrd.conf
-echo "rpcbind=0.0.0.0" >> /data/.lbrycrd/lbrycrd.conf
-#echo "bind=0.0.0.0" >> /data/.lbrycrd/lbrycrd.conf
 
 ## Control this invocation through envvar.
 case $RUN_MODE in
   default )
-    su -c "lbrycrdd -server -conf=/data/.lbrycrd/lbrycrd.conf -printtoconsole" lbrycrd
+    lbrycrdd -server -conf=$CONFIG_PATH -printtoconsole
     ;;
   reindex )
-    su -c "lbrycrdd -server -txindex -reindex -conf=/data/.lbrycrd/lbrycrd.conf -printtoconsole" lbrycrd
+    lbrycrdd -server -txindex -reindex -conf=$CONFIG_PATH -printtoconsole
     ;;
   chainquery )
-    su -c "lbrycrdd -server -txindex -conf=/data/.lbrycrd/lbrycrd.conf -printtoconsole" lbrycrd
+    lbrycrdd -server -txindex -conf=$CONFIG_PATH -printtoconsole
     ;;
 esac


### PR DESCRIPTION
This is an adaptation on the config style. In the case the user wants to mount his own config file, he can do so. If he does not, the environment variables are used instead to create a default config.

 * The config file is moved from /data/.lbrycrd/lbrycrd.conf to /etc/lbry/lbrycrd.conf, this way we know we are starting fresh each time, either provided config, or new config.
 * Got rid of su and use the USER directive in the Dockerfile instead.

With these changes I can fix #45 