### PR TITLE
Adds new multi-stage Dockerfile for lbrycrd and mountable config files.

### DIFF
--- a/lbrycrd/Dockerfile
+++ b/lbrycrd/Dockerfile
@@ -1,45 +1,30 @@
-## This base image is for running latest lbrycrdd
-# For some reason I may switch this image over to Alpine when I can RCA why it won't start.
-FROM ubuntu:18.04
+FROM ubuntu:18.04 as prep
 LABEL MAINTAINER="leopere [at] nixc [dot] us"
+## TODO: Implement version pinning. `apt-get install curl=<version>`
+RUN apt-get update && \
+  apt-get -y install unzip curl build-essential && \
+  apt-get autoclean -y && \
+  rm -rf /var/lib/apt/lists/*
+WORKDIR /
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+COPY stuff/start.sh start
+COPY stuff/healthcheck.sh healthcheck
+COPY stuff/fix-permissions.c fix-permissions.c
+RUN curl -L -o ./lbrycrd-linux.zip $(curl -s https://api.github.com/repos/lbryio/lbrycrd/releases | grep -F 'lbrycrd-linux.zip' | grep download | head -n 1 | cut -d'"' -f4) && \
+  unzip ./lbrycrd-linux.zip && \
+  gcc fix-permissions.c -o fix-permissions && \
+  chmod +x ./lbrycrdd ./lbrycrd-cli ./lbrycrd-tx ./start ./healthcheck ./fix-permissions
 
+FROM ubuntu:18.04 as app
+COPY --from=prep /lbrycrdd /lbrycrd-cli /lbrycrd-tx /start /healthcheck /fix-permissions /usr/bin/
 RUN addgroup --gid 1000 lbrycrd && \
-    adduser lbrycrd --uid 1000 --gid 1000 --gecos GECOS --shell /bin/bash --disabled-password --home /data && \
-    apt-get update && \
-    apt-get -y install unzip wget curl && \
-    apt-get autoclean -y && \
-    rm -rf /var/lib/apt/lists/*
-
-## TODO: Consider adding debugpaste or variant
-# RUN wget -O /usr/bin/debugpaste https://github.com/nixc-us/debugpaste-it/raw/master/bin/debugpaste_64 && \
-#     chmod +x /usr/bin/debugpaste
-
-RUN wget -O /usr/bin/lbrycrd-linux.zip https://github.com/lbryio/lbrycrd/releases/download/v0.12.2.2/lbrycrd-linux.zip && \
-    cd /usr/bin/ && \
-    unzip lbrycrd-linux.zip && \
-    rm lbrycrd-linux.zip && \
-    chmod +x lbrycrdd lbrycrd-cli lbrycrd-tx
-
-COPY stuff/debugpaste-it.sh /usr/local/bin/debugpaste-it
-COPY stuff/start.sh /usr/local/bin/start
-COPY stuff/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
-COPY stuff/healthcheck.sh /usr/local/bin/healthcheck
-
-# USER lbrycrd
-# RUN mkdir /data
+  adduser lbrycrd --uid 1000 --gid 1000 --gecos GECOS --shell /bin/bash --disabled-password --home /data && \
+  chmod a+s /usr/bin/fix-permissions
 VOLUME ["/data"]
 WORKDIR /data
-
 ## TODO: Implement healthcheck.
 # HEALTHCHECK ["healthcheck"]
+EXPOSE 9246 9245
 
-## Exposing daemon port and RPC port
-EXPOSE 9245 9246
-
-## TODO: Decide what's important for lbrycrd and possibly add an entrypoint.
-## Maybe catch things that might match things that can be easily executed in the
-## lbrycrd cli and if nothing is entered just default to the containers shell.
-## For now this is a placeholder that executes /bin/bash on `docker exec`
-# ENTRYPOINT ["docker-entrypoint"]
-
+USER lbrycrd
 CMD ["start"]

--- a/lbrycrd/stuff/fix-permissions.c
+++ b/lbrycrd/stuff/fix-permissions.c
@@ -1,0 +1,9 @@
+#include <unistd.h>
+int main() {
+  // This program needs to run with setuid == root
+  // This needs to be in a compiled language because you cannot setuid bash scripts
+  setuid(0);
+  execle("/bin/bash", "bash", "-c",
+         "/bin/chown -R lbrycrd:lbrycrd /data && /bin/chmod -R 755 /data/",
+         (char*) NULL, (char*) NULL);
+}


### PR DESCRIPTION
This Dockerfile was originally outlined by @Leopere here:
https://github.com/lbryio/lbry-docker/pull/46#issuecomment-483779947

This follows threads from #45 and #46 

I've made the following additions:

 * Made it so the config file can be mounted to /etc/lbry/lbrycrd.conf
    * If no config file is mounted, then the config is created from the environment variables just as before.
 * Added 'USER lbrycrd' to the Dockerfile. 
   * Previously with the de-escalation of priviliges was only occuring if you used start.sh command. This makes it so all commands run as the lbrycrd user.
 * Added fix-permissions command, a simple c-wrapper around bash and setuid=root so that we can still change the file permissions even though we are no longer running as root.
    * This needed to be written in c only because you can't setuid in bash. 
    * See https://unix.stackexchange.com/a/2910
    * Nice thing about the multi-stage docker build is that we can pull over just the 8KB executable into the final image, and not the whole compiler chain.
