### PR TITLE
Adds ENTRYPOINT to lbrynet to require mounted home directory before execute

### DIFF
--- a/lbrynet/Dockerfile-armhf-compiler
+++ b/lbrynet/Dockerfile-armhf-compiler
@@ -37,18 +37,21 @@ RUN git clone https://github.com/lbryio/torba.git --depth 1 /lbry/torba
 WORKDIR /lbry/torba
 RUN python3.7 -m pip install -e .
 WORKDIR /lbry/
+COPY stuff/start.sh /usr/local/bin/start
+COPY stuff/checkmount.sh /usr/local/bin/checkmount
 RUN python3.7 scripts/set_build.py && \
     python3.7 -m pip install -e . && \
     pyinstaller -F -n lbrynet lbrynet/extras/cli.py && \
     chmod +x /lbry/dist/lbrynet && \
     zip -j /lbry/dist/lbrynet-armhf.zip /lbry/dist/lbrynet && \
+    chmod a+x /usr/local/bin/* && \
     mkdir /target && \
     /lbry/dist/lbrynet --version
 
 FROM multiarch/ubuntu-core:armhf-bionic as app
 RUN adduser lbrynet --gecos GECOS --shell /bin/bash --disabled-password --home /home/lbrynet
-COPY stuff/start.sh /usr/local/bin/start
-COPY --from=compile /lbry/dist/lbrynet /usr/local/bin/
+COPY --from=compile /usr/local/bin/start /usr/local/bin/checkmount /lbry/dist/lbrynet /usr/local/bin/
 EXPOSE 5279
 USER lbrynet
+ENTRYPOINT ["/usr/local/bin/checkmount"]
 CMD ["start"]

--- a/lbrynet/Dockerfile-x86_64-compiler
+++ b/lbrynet/Dockerfile-x86_64-compiler
@@ -37,18 +37,21 @@ RUN git clone https://github.com/lbryio/torba.git --depth 1 /lbry/torba
 WORKDIR /lbry/torba
 RUN python3.7 -m pip install -e .
 WORKDIR /lbry/
+COPY stuff/start.sh /usr/local/bin/start
+COPY stuff/checkmount.sh /usr/local/bin/checkmount
 RUN python3.7 scripts/set_build.py && \
     python3.7 -m pip install -e . && \
     pyinstaller -F -n lbrynet lbrynet/extras/cli.py && \
     chmod +x /lbry/dist/lbrynet && \
     zip -j /lbry/dist/lbrynet-armhf.zip /lbry/dist/lbrynet && \
+    chmod a+x /usr/local/bin/* && \
     mkdir /target && \
     /lbry/dist/lbrynet --version
 
 FROM ubuntu:18.04 as app
 RUN adduser lbrynet --gecos GECOS --shell /bin/bash --disabled-password --home /home/lbrynet
-COPY stuff/start.sh /usr/local/bin/start
-COPY --from=compile /lbry/dist/lbrynet /usr/local/bin/
+COPY --from=compile /usr/local/bin/start /usr/local/bin/checkmount /lbry/dist/lbrynet /usr/local/bin/
 EXPOSE 5279
 USER lbrynet
+ENTRYPOINT ["/usr/local/bin/checkmount"]
 CMD ["start"]

--- a/lbrynet/stuff/checkmount.sh
+++ b/lbrynet/stuff/checkmount.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+mountpoint=/home/lbrynet
+
+if ! grep -qs ".* $mountpoint " /proc/mounts; then
+    echo "$mountpoint not mounted, refusing to run."
+    exit 1
+else
+    `$@`
+fi
+


### PR DESCRIPTION
This fixes #55 by having the lbrynet container always check for the a mounted `/home/lbrynet` directory before execution.

This is accomplised by an ENTRYPOINT that runs before lbrynet does, that checks for the directory mount status, and then passes all args on to the system for execution.