### PR TITLE
Creates a layered configuration for lbrycrd start.sh

### DIFF
--- a/lbrycrd/README.md
+++ b/lbrycrd/README.md
@@ -2,3 +2,47 @@
 # Docker image tags
 `lbry/lbrycrd`
 `[linux-x86_64-production](https://github.com/lbryio/lbry-docker/blob/master/lbrycrd/Dockerfile-linux-x86_64-production)` (Latest release)
+
+
+## Configuration
+
+The lbrycrd container comes with a default configuration you can use for
+production. Extra configuration is optional.
+
+The container includes a `start` script that offers a flexible configuration
+style. It allows you to mount your own `lbrycrd.conf` file, or use environment
+variables, or a mix of both.
+
+### Environment variables
+
+The environment variables override the values in the mounted config file. If no
+mounted config file exists, these variables are used to create a fresh config.
+
+ * `PORT` - The main lbrycrd port
+ * `RPC_USER` - The rpc user
+ * `RPC_PASSWORD` - The rpc user's password
+ * `RPC_ALLOW_IP` - the subnet that is allowed rpc access
+ * `RPC_PORT` - The port to bind the rpc service to
+ * `RPC_BIND` - The ip address to bind the rpc service to
+ 
+
+### Example run commands
+
+Running the default configuration:
+
+```
+docker run --rm -it -e RUN_MODE=default lbry/lbrycrd:linux-x86_64-production
+```
+
+Running with RPC password changed:
+
+```
+docker run --rm -it -e RUN_MODE=default -e RPC_PASSWORD=hunter2 lbry/lbrycrd:linux-x86_64-production
+```
+
+Running with a config file but with the RPC password still overridden:
+
+```
+docker run --rm -it -v /path/to/lbrycrd.conf:/etc/lbry/lbrycrd.conf -e RUN_MODE=default -e RPC_PASSWORD=hunter2 lbry/lbrycrd:linux-x86_64-production
+```
+

--- a/lbrycrd/stuff/start.sh
+++ b/lbrycrd/stuff/start.sh
@@ -1,23 +1,53 @@
 #!/usr/bin/env bash
 CONFIG_PATH=/etc/lbry/lbrycrd.conf
 
+function override_config_option() {
+    # Remove existing config line from a config file
+    #  and replace with environment fed value.
+    # Does nothing if the variable does not exist.
+    #  var     Name of ENV variable
+    #  option  Name of config option
+    #  config  Path of config file
+    local var=$1 option=$2 config=$3
+    if [[ -v $var ]]; then
+        # Remove the existing config option:
+        sed -i "/^$option\W*=/d" $config
+        # Add the value from the environment:
+        echo "$option=${!var}" >> $config
+    fi
+}
+
 function set_config() {
-  CONFIG_PATH=/etc/lbry/lbrycrd.conf
-  if [ -f "$CONFIG_PATH" ]
-  then
-      echo "Using the config file that was mounted into the container."
+  if [ -d "$CONFIG_PATH" ]; then
+      echo "$CONFIG_PATH is a directory when it should be a file."
+      exit 1
+  elif [ -f "$CONFIG_PATH" ]; then
+      echo "Merging the mounted config file with environment variables."
+      local MERGED_CONFIG=/tmp/lbrycrd_merged.conf
+      cat $CONFIG_PATH > $MERGED_CONFIG
+      echo "" >> $MERGED_CONFIG
+      override_config_option PORT port $MERGED_CONFIG
+      override_config_option RPC_USER rpcuser $MERGED_CONFIG
+      override_config_option RPC_PASSWORD rpcpassword $MERGED_CONFIG
+      override_config_option RPC_ALLOW_IP rpcallowip $MERGED_CONFIG
+      override_config_option RPC_PORT rpcport $MERGED_CONFIG
+      override_config_option RPC_BIND rpcbind $MERGED_CONFIG
+      # Make the new merged config file the new CONFIG_PATH
+      # This ensures that the original file the user mounted remains unmodified
+      CONFIG_PATH=$MERGED_CONFIG
   else
       echo "Creating a fresh config file from environment variables."
       ## Set config params
-      echo "rpcuser=$RPC_USER" > $CONFIG_PATH
-      echo "rpcpassword=$RPC_PASSWORD" >> $CONFIG_PATH
-      echo "rpcallowip=$RPC_ALLOW_IP" >> $CONFIG_PATH
-      echo "rpcport=9245" >> $CONFIG_PATH
-      echo "rpcbind=0.0.0.0" >> $CONFIG_PATH
-      #echo "bind=0.0.0.0" >> $CONFIG_PATH
+      echo "port=${PORT=9246}" > $CONFIG_PATH
+      echo "rpcuser=${RPC_USER=lbry}" >> $CONFIG_PATH
+      echo "rpcpassword=${RPC_PASSWORD=lbry}" >> $CONFIG_PATH
+      echo "rpcallowip=${RPC_ALLOW_IP=127.0.0.1/24}" >> $CONFIG_PATH
+      echo "rpcport=${RPC_PORT=9245}" >> $CONFIG_PATH
+      echo "rpcbind=${RPC_BIND=0.0.0.0}" >> $CONFIG_PATH
   fi
+  echo "Config: "
+  cat $CONFIG_PATH
 }
-
 
 ## Ensure perms are correct prior to running main binary
 /usr/bin/fix-permissions


### PR DESCRIPTION
We already fixed it so you could specify the config file or have one generated, but we left the case open where the user could specify both environment vars and a config file.

The environment variables always supercede the values in the configuration file.

There are a few example run commands in the README.