### PR TITLE
lbrynet-multiarch-compiler steps require TRAVIS_COMMIT env var.

### DIFF
--- a/lbrynet/Dockerfile-linux-multiarch-compiler
+++ b/lbrynet/Dockerfile-linux-multiarch-compiler
@@ -51,7 +51,8 @@ RUN python3.7 -m pip install -e .
 WORKDIR /lbry/
 COPY stuff/start.sh /usr/local/bin/start
 COPY stuff/checkmount.sh /usr/local/bin/checkmount
-RUN python3.7 scripts/set_build.py && \
+RUN export TRAVIS_COMMIT=`git rev-parse HEAD` && \
+    python3.7 scripts/set_build.py && \
     python3.7 -m pip install -e . && \
     pyinstaller -F -n lbrynet lbrynet/extras/cli.py && \
     chmod +x /lbry/dist/lbrynet && \


### PR DESCRIPTION
Introduced in [lbrynet commit #925e39c5a](https://github.com/lbryio/lbry/commit/925e39c5a80952f7e7a3018b17327824af0f4395#diff-617ad45cf870bcc9e06d8c2938f8666d),  the compile steps require setting TRAVIS_COMMIT environment variable.