### PR TITLE
Multi-stage Dockerfile for spee.ch

### DIFF
--- a/spee.ch/Dockerfile
+++ b/spee.ch/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:18.04 as prep
+LABEL MAINTAINER="leopere [at] nixc [dot] us"
+RUN apt-get update && \
+    apt-get install -y \
+      git \
+      curl \
+      unzip \
+      ffmpeg \
+      nodejs \
+      npm \
+      imagemagick
+ARG REPO=https://github.com/lbryio/spee.ch
+ARG VERSION=master
+RUN git clone ${REPO} /spee.ch && \
+    cd /spee.ch && \
+    git checkout ${VERSION} && \
+    rm -rf .git && \
+    npm install
+
+FROM ubuntu:18.04 as app
+RUN apt-get update && \
+    apt-get install -y \
+      nodejs \
+      ffmpeg \
+      imagemagick \
+      npm
+COPY --from=prep /spee.ch /spee.ch
+WORKDIR /spee.ch
+CMD /usr/bin/npm run build && /usr/bin/npm run start


### PR DESCRIPTION
This creates a spee.ch container.

Spee.ch imports its configuration from its own bundle. This means that we need to have the whole configuration at bundle time. Since we don't have the configuration until runtime, this force us to create the bundle at runtime. 

Ideally, the final image would not even have npm in it. Simply copying the node_modules from the `prep` stage over to the `app` stage, and mounting the configuration files should be sufficient. However, this would require a change to how spee.ch imports its configuration.

For now, this works with the way spee.ch currently works.